### PR TITLE
Use `DocumentReference` instead of `String`.

### DIFF
--- a/app/src/main/java/tec/ac/cr/marape/app/model/Inventory.kt
+++ b/app/src/main/java/tec/ac/cr/marape/app/model/Inventory.kt
@@ -1,5 +1,6 @@
 package tec.ac.cr.marape.app.model
 
+import com.google.firebase.firestore.DocumentReference
 import java.io.Serializable
 
 
@@ -14,5 +15,6 @@ data class Inventory(
   var creationDate: Long = 0,
   var active: Boolean = false,
   var ownerEmail: String = "",
-  var invitedUsers: List<String> = emptyList(),
+  var invitedUsers: List<DocumentReference> = emptyList(),
+  var items: List<DocumentReference> = emptyList()
 ) : Serializable


### PR DESCRIPTION
We won't be using strings anymore to refer to the invited users, instead we'll be using references to their documents, that way we can access them without having to call `<db>.document(...)` instead we can call `get` directly on the reference that was returned by the database, this is honestly pretty mild and it may cause a bit of trouble for other use cases, but we'll see how it evolves and how it affects everything else in the future.